### PR TITLE
Wrapper script that sets up AWS infra

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ by default nowadays?
 6. Public subnet's IPv6 CIDR: Specify a custom IPv6 CIDR
 7. Create VPC
 
+## Create security group
 1. https://sa-east-1.console.aws.amazon.com/ec2/v2/home
 2. Security Groups
 3. Create Security Group
@@ -55,12 +56,24 @@ by default nowadays?
 1. Execute `./vpn.sh <the path to the secret key file> <the instance public IP>`
 2. When done, run `wg-quick down wg0` and terminate the instance
 
+### Launching an EC2 instance + VPN with a script
+Alternatively, you can launch an EC2 instance via the script `start-vpn.sh`.
+The script has some requirements that must be fulfilled for it to work properly:
+- [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+- a [configured named profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) for your `aws-cli` enviroment
+- [jq](https://stedolan.github.io/jq/) installed
+- the ids of the security group and subnet created in the infra setup steps above
+
+The script was only tested on Ubuntu.
+
+1. Execute `./start-vpn.sh <desired AWS region> <local profile name> <the previously created subnet id> <the previously created security group id> <the secret key name> <the path to the secret key file>`
+2. The script will ask for some user inputs, in the form of consenting with `yes` or sudo access to install the required packages
+3. When done with spinning up the EC2 instance and with configuring the VPN, the script will hang
+4. Pressing CTRL+c will trigger its tear down function, that terminates the previously launched EC2 instance and turns off WireGuard
+ 
 ## References
 
-https://www.stavros.io/posts/how-to-configure-wireguard/ no ipv6
-
-https://www.ckn.io/blog/2017/11/14/wireguard-vpn-typical-setup/ dns no ubuntu 18 no ipv6
-
-https://dnns.no/wireguard-vpn-on-ubuntu-18.04.html no-dns
-
-https://docs.aws.amazon.com/vpc/latest/userguide/get-started-ipv6.html
+- https://www.stavros.io/posts/how-to-configure-wireguard/ no ipv6
+- https://www.ckn.io/blog/2017/11/14/wireguard-vpn-typical-setup/ dns no ubuntu 18 no ipv6
+- https://dnns.no/wireguard-vpn-on-ubuntu-18.04.html no-dns
+- https://docs.aws.amazon.com/vpc/latest/userguide/get-started-ipv6.html

--- a/start-vpn.sh
+++ b/start-vpn.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+if [[ $# -lt 6 ]]; then
+  echo "Usage: $0 <AWS_REGION> <AWS_PROFILE> <AWS_SUBNET_ID> <AWS_SECURITY_GROUP_ID> <AWS_KEY_NAME> <AWS_IDENTITY_FILE>"
+  exit
+fi
+
+AWS_REGION=$1
+AWS_PROFILE=$2
+AWS_SUBNET_ID=$3
+AWS_SECURITY_GROUP_ID=$4
+AWS_KEY_NAME=$5
+AWS_IDENTITY_FILE=$6
+
+export AWS_PAGER=""
+
+CREATE_INSTANCE_RESPONSE=$(aws --profile $AWS_PROFILE --region $AWS_REGION ec2 run-instances --image-id ami-090006f29ecb2d79a --instance-type t2.micro --subnet-id $AWS_SUBNET_ID --associate-public-ip-address --ipv6-address-count 1 --security-group-ids $AWS_SECURITY_GROUP_ID --key-name $AWS_KEY_NAME)
+
+echo "EC2 run-instances API called"
+
+INSTANCE_ID=$(echo $CREATE_INSTANCE_RESPONSE | jq '.Instances[0].InstanceId' --raw-output)
+
+echo "Created instance with ID: $INSTANCE_ID"
+
+DESCRIBE_INSTANCE_RESPONSE=$(aws --profile $AWS_PROFILE --region $AWS_REGION ec2 describe-instances --instance-ids $INSTANCE_ID)
+
+PUBLIC_IP_ADDRESS=$(echo $DESCRIBE_INSTANCE_RESPONSE | jq '.Reservations[0].Instances[0].PublicIpAddress' --raw-output)
+
+echo "Instance's public IP address is $PUBLIC_IP_ADDRESS"
+
+STATE_CHECKS_COUNT=1
+while [ $STATE_CHECKS_COUNT -le 10 ];
+do
+    echo "Checking instance $INSTANCE_ID state"
+    DESCRIBE_INSTANCE_RESPONSE=$(aws --profile $AWS_PROFILE --region $AWS_REGION ec2 describe-instances --instance-ids $INSTANCE_ID)
+    INSTANCE_STATE=$(echo $DESCRIBE_INSTANCE_RESPONSE | jq '.Reservations[0].Instances[0].State.Name' --raw-output)
+    if [[ "$INSTANCE_STATE" == "running" ]]; then
+        echo -e "Instance state is \033[0;32m$INSTANCE_STATE\033[0m"
+        echo "Will wait 15 seconds before attempting to SSH to it"
+        sleep 15
+        break
+    else 
+        echo -e "Instance state is \033[0;33m$INSTANCE_STATE\033[0m"
+    fi
+    echo "Will wait 5 seconds before checking again..."
+    sleep 5
+done
+
+./vpn.sh $AWS_IDENTITY_FILE $PUBLIC_IP_ADDRESS
+
+function tear_down {
+    printf "\n\nVPN will be shutdown\n\n"
+    TERMINATE_INSTANCE_RESPONSE=$(aws --profile $AWS_PROFILE --region $AWS_REGION ec2 terminate-instances --instance-ids $INSTANCE_ID)
+    printf "Terminate instances call response was:\n$TERMINATE_INSTANCE_RESPONSE\n\n"
+    wg-quick down wg0
+    ssh-keygen -R $PUBLIC_IP_ADDRESS
+}
+
+trap tear_down EXIT
+
+echo "Nice, the VPN is up and running. Press ctrl+c to stop it"
+
+# waits forever
+tail -f /dev/null


### PR DESCRIPTION
Wrapper script that sets up AWS infra before launching the VPN script. It also tears down said infra.

Manual steps on the README file are still expected to be followed.